### PR TITLE
Add simple Tinder-like app skeleton

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,41 @@
+from flask import Flask, jsonify, render_template
+
+app = Flask(__name__)
+
+# Sample profile data
+profiles = [
+    {
+        "name": "Alicja",
+        "age": 25,
+        "bio": "Uwielbia górskie wędrówki",
+        "image": "https://via.placeholder.com/300x400?text=Alicja"
+    },
+    {
+        "name": "Bartek",
+        "age": 30,
+        "bio": "Miłośnik kawy i podróży",
+        "image": "https://via.placeholder.com/300x400?text=Bartek"
+    },
+    {
+        "name": "Celina",
+        "age": 28,
+        "bio": "Programistka i fanatyczka kotów",
+        "image": "https://via.placeholder.com/300x400?text=Celina"
+    }
+]
+
+current = 0
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/profile')
+def get_profile():
+    global current
+    profile = profiles[current % len(profiles)]
+    current += 1
+    return jsonify(profile)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="pl">
+<head>
+    <meta charset="utf-8" />
+    <title>Prosta aplikacja Tinder</title>
+    <script>
+        async function loadProfile() {
+            const response = await fetch('/profile');
+            const data = await response.json();
+            document.getElementById('name').textContent = `${data.name}, ${data.age}`;
+            document.getElementById('bio').textContent = data.bio;
+            document.getElementById('photo').src = data.image;
+        }
+
+        function like() { loadProfile(); }
+        function dislike() { loadProfile(); }
+
+        window.onload = loadProfile;
+    </script>
+</head>
+<body>
+    <div>
+        <img id="photo" src="" alt="zdjęcie" width="300" />
+        <h2 id="name"></h2>
+        <p id="bio"></p>
+        <button onclick="dislike()">Nie</button>
+        <button onclick="like()">Tak</button>
+    </div>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import app
+
+def test_index():
+    client = app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200
+
+
+def test_profile():
+    client = app.test_client()
+    response = client.get('/profile')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'name' in data
+    assert 'bio' in data
+    assert 'image' in data


### PR DESCRIPTION
## Summary
- basic Flask server serving profile data
- simple HTML page with like/dislike swapping
- tests for root and profile endpoints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f78dcbcc0832fb6368be94cb85e46