### PR TITLE
Add swipe tracking backend and improve frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app.py
+++ b/app.py
@@ -1,0 +1,66 @@
+from flask import Flask, jsonify, render_template, request, session
+
+app = Flask(__name__)
+app.secret_key = "dev-secret"
+
+# Sample profile data
+profiles = [
+    {
+        "id": 0,
+        "name": "Alicja",
+        "age": 25,
+        "bio": "Uwielbia górskie wędrówki",
+        "image": "https://via.placeholder.com/300x400?text=Alicja",
+    },
+    {
+        "id": 1,
+        "name": "Bartek",
+        "age": 30,
+        "bio": "Miłośnik kawy i podróży",
+        "image": "https://via.placeholder.com/300x400?text=Bartek",
+    },
+    {
+        "id": 2,
+        "name": "Celina",
+        "age": 28,
+        "bio": "Programistka i fanatyczka kotów",
+        "image": "https://via.placeholder.com/300x400?text=Celina",
+    },
+]
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/profile')
+def get_profile():
+    idx = session.get("current", 0)
+    profile = profiles[idx % len(profiles)]
+    session["current"] = idx + 1
+    session.modified = True
+    return jsonify(profile)
+
+
+@app.post('/swipe')
+def swipe():
+    data = request.get_json() or {}
+    pid = data.get("id")
+    action = data.get("action")
+    liked = session.setdefault("liked", [])
+    disliked = session.setdefault("disliked", [])
+    if action == "like" and pid not in liked:
+        liked.append(pid)
+    elif action == "dislike" and pid not in disliked:
+        disliked.append(pid)
+    session.modified = True
+    return jsonify({"liked_count": len(liked)})
+
+
+@app.route('/liked')
+def liked_profiles():
+    liked_ids = session.get("liked", [])
+    liked = [p for p in profiles if p["id"] in liked_ids]
+    return jsonify(liked)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="pl">
+    <head>
+        <meta charset="utf-8" />
+        <title>Prosta aplikacja Tinder</title>
+        <script>
+            let currentId = null;
+
+            async function loadProfile() {
+                const response = await fetch('/profile');
+                const data = await response.json();
+                currentId = data.id;
+                document.getElementById('name').textContent = `${data.name}, ${data.age}`;
+                document.getElementById('bio').textContent = data.bio;
+                document.getElementById('photo').src = data.image;
+            }
+
+            async function swipe(action) {
+                await fetch('/swipe', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({id: currentId, action})
+                }).then(r => r.json()).then(res => {
+                    document.getElementById('liked-count').textContent = `Polubione: ${res.liked_count}`;
+                });
+                loadProfile();
+            }
+
+            function like() { swipe('like'); }
+            function dislike() { swipe('dislike'); }
+
+            window.onload = loadProfile;
+        </script>
+    </head>
+    <body>
+        <div id="liked-count">Polubione: 0</div>
+        <div>
+            <img id="photo" src="" alt="zdjęcie" width="300" />
+            <h2 id="name"></h2>
+            <p id="bio"></p>
+            <button onclick="dislike()">Nie</button>
+            <button onclick="like()">Tak</button>
+        </div>
+    </body>
+    </html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import app
+
+def test_index():
+    client = app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200
+
+
+def test_profile():
+    client = app.test_client()
+    response = client.get('/profile')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'id' in data
+    assert 'name' in data
+    assert 'bio' in data
+    assert 'image' in data
+
+
+def test_swipe_and_liked():
+    client = app.test_client()
+    profile = client.get('/profile').get_json()
+    res = client.post('/swipe', json={'id': profile['id'], 'action': 'like'})
+    assert res.status_code == 200
+    assert res.get_json()['liked_count'] == 1
+
+    liked = client.get('/liked').get_json()
+    assert any(p['id'] == profile['id'] for p in liked)
+
+
+def test_profile_sequence_is_session_isolated():
+    client1 = app.test_client()
+    client2 = app.test_client()
+
+    first1 = client1.get('/profile').get_json()['id']
+    first2 = client2.get('/profile').get_json()['id']
+    assert first1 == first2 == 0
+
+    second1 = client1.get('/profile').get_json()['id']
+    second2 = client2.get('/profile').get_json()['id']
+    assert second1 == second2 == 1


### PR DESCRIPTION
## Summary
- track likes/dislikes in Flask session and expose `/swipe` and `/liked` endpoints
- enhance page to send swipe actions and show count of liked profiles
- expand tests to cover profile IDs and swipe flow
- store profile index in user session to avoid cross-user conflicts and test session isolation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f78dcbcc0832fb6368be94cb85e46