### PR TITLE
Add configurable Starknet chainId

### DIFF
--- a/README_starknet.md
+++ b/README_starknet.md
@@ -2,7 +2,7 @@
 
 ## Setup
 1) `npm i`  
-2) `.env` uzupełnij: `STARKNET_RPC_URL`, `STARKNET_ACCOUNT_ADDRESS`, `STARKNET_PRIVATE_KEY`, `STARKNET_TOKEN_ADDRESS`.  
+2) `.env` uzupełnij: `STARKNET_RPC_URL`, `STARKNET_ACCOUNT_ADDRESS`, `STARKNET_PRIVATE_KEY`, `STARKNET_TOKEN_ADDRESS`, `STARKNET_CHAIN_ID`.
 3) (Opcjonalnie) `npm run build` lub używaj `ts-node`.
 
 ## CSV format

--- a/scripts/starknet/airdrop.ts
+++ b/scripts/starknet/airdrop.ts
@@ -14,7 +14,7 @@ import { parseAmountHumanToWei } from '../../src/chains/starknet/u256';
     .option('out', { type: 'string', default: 'starknet_airdrop_result.csv' })
     .parseSync();
 
-  const adapter = new StarknetAdapter();
+  const adapter = new StarknetAdapter({ chainId: process.env.STARKNET_CHAIN_ID });
   const decimals = await adapter.getDecimals();
   const csv = fs.readFileSync(String(argv.csv), 'utf8');
   const rows: Array<{ address: string; amount: string }> = parse(csv, { columns: true, skip_empty_lines: true });

--- a/scripts/starknet/balance.ts
+++ b/scripts/starknet/balance.ts
@@ -9,7 +9,7 @@ import { StarknetAdapter } from '../../src/chains/starknet/StarknetAdapter';
     .option('human', { type: 'boolean', default: true })
     .parseSync();
 
-  const adapter = new StarknetAdapter();
+  const adapter = new StarknetAdapter({ chainId: process.env.STARKNET_CHAIN_ID });
   const bal = await adapter.getBalanceOf(String(argv.address));
   if (argv.human) {
     const d = await adapter.getDecimals();

--- a/scripts/starknet/estimate.ts
+++ b/scripts/starknet/estimate.ts
@@ -13,7 +13,7 @@ import { parseAmountHumanToWei } from '../../src/chains/starknet/u256';
     .option('units', { type: 'string', choices: ['human', 'wei'], default: 'human' })
     .parseSync();
 
-  const adapter = new StarknetAdapter();
+  const adapter = new StarknetAdapter({ chainId: process.env.STARKNET_CHAIN_ID });
   const csv = fs.readFileSync(String(argv.csv), 'utf8');
   const rows: Array<{ address: string; amount: string }> = parse(csv, { columns: true, skip_empty_lines: true });
   const decimals = await adapter.getDecimals();

--- a/src/chains/starknet/StarknetAdapter.ts
+++ b/src/chains/starknet/StarknetAdapter.ts
@@ -10,20 +10,29 @@ export class StarknetAdapter {
   account: Account;
   tokenAddress: string;
 
-  constructor(cfg?: { rpcUrl?: string; accountAddress?: string; privateKey?: string; tokenAddress?: string }) {
+  constructor(cfg?: {
+    rpcUrl?: string;
+    accountAddress?: string;
+    privateKey?: string;
+    tokenAddress?: string;
+    chainId?: string;
+  }) {
     const rpcUrl = cfg?.rpcUrl ?? process.env.STARKNET_RPC_URL!;
     const accountAddress = cfg?.accountAddress ?? process.env.STARKNET_ACCOUNT_ADDRESS!;
     const privateKey = cfg?.privateKey ?? process.env.STARKNET_PRIVATE_KEY!;
     this.tokenAddress = cfg?.tokenAddress ?? process.env.STARKNET_TOKEN_ADDRESS!;
+    const chainId = cfg?.chainId ?? process.env.STARKNET_CHAIN_ID;
 
-    if (!rpcUrl || !accountAddress || !privateKey || !this.tokenAddress) {
-      throw new Error('Missing Starknet env: STARKNET_RPC_URL, STARKNET_ACCOUNT_ADDRESS, STARKNET_PRIVATE_KEY, STARKNET_TOKEN_ADDRESS');
+    if (!rpcUrl || !accountAddress || !privateKey || !this.tokenAddress || !chainId) {
+      throw new Error(
+        'Missing Starknet env: STARKNET_RPC_URL, STARKNET_ACCOUNT_ADDRESS, STARKNET_PRIVATE_KEY, STARKNET_TOKEN_ADDRESS, STARKNET_CHAIN_ID'
+      );
     }
 
-    this.provider = new RpcProvider({ nodeUrl: rpcUrl });
+    this.provider = new RpcProvider({ nodeUrl: rpcUrl, chainId: chainId as any });
     const accAddrParsed = validateAndParseAddress(accountAddress);
     this.tokenAddress = validateAndParseAddress(this.tokenAddress);
-    this.account = new Account(this.provider, accAddrParsed, privateKey);
+    this.account = new Account({ nodeUrl: rpcUrl, chainId: chainId as any }, accAddrParsed, privateKey);
   }
 
   private erc20Read(): Contract {


### PR DESCRIPTION
## Summary
- allow passing chainId to StarknetAdapter and wire it into RpcProvider and Account
- pass chainId from env in Starknet scripts and document required env var

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689731214684832fbf8c15a3f5ec860f